### PR TITLE
Add NRD library to Lumen project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 **/Sandbox/Sandbox.dir/**
 **/Lumen/vendor/Glad/Glad.dir/**
 **/Lumen/vendor/imgui/ImGui.dir/**
+**/LumenPT/vendor/RayTracingDenoiser
 
 G:\RandomCode\LumenRenderer\Lumen_Engine\Sandbox\assets\models\Sponza
 

--- a/Lumen_Engine/CMakeLists.txt
+++ b/Lumen_Engine/CMakeLists.txt
@@ -12,6 +12,7 @@ set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 option(USE_WAVEFRONT "Use the Wavefront rendering pipeline?" ON)
+option(USE_NVIDIA_DENOISER "Use Nvidia denoiser?" OFF)
 
 add_subdirectory("Lumen/vendor/GLFW")
 	#Glad
@@ -42,6 +43,10 @@ set(BOOST_LIBRARYDIR "${CMAKE_CURRENT_SOURCE_DIR}/LumenPT/vendor/Libs/boost")
 add_subdirectory ("LumenPT/vendor/openvdb")
 	#NanoVDB
 add_subdirectory ("LumenPT/vendor/openvdb/nanovdb")
+	#NRD
+if(${USE_NVIDIA_DENOISER})
+	add_subdirectory ("LumenPT/vendor/RayTracingDenoiser")
+endif()
 	#Lumen
 add_subdirectory ("Lumen")
 	#LumenPT


### PR DESCRIPTION
Note: NRD library is in a private repo at https://github.com/LumenPT/RayTracingDenoiser. Follow instructions there in Readme to add to Lumen project.