### PR TITLE
[*] (Tried to make) CUDA shader copying more reliable.

### DIFF
--- a/Lumen_Engine/LumenPT/CMakeLists.txt
+++ b/Lumen_Engine/LumenPT/CMakeLists.txt
@@ -60,9 +60,13 @@ message("----------------------------------------------")
 
 add_custom_command(
 	OUTPUT ${CUDA_FILES_OUTPUT}
+	COMMAND if exist "${CUDA_FILES_OUTPUT_DIR}\\" 
+			${CMAKE_COMMAND} -E rm -rf "${CUDA_FILES_OUTPUT_DIR}\\" &&
+			${CMAKE_COMMAND} -E echo "[INFO]: Cleaned up shader directory: ${CUDA_FILES_OUTPUT_DIR}"
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${CUDA_FILES_OUTPUT_DIR}
-	COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_OBJECTS:CUDAShaders> ${CUDA_FILES_OUTPUT_DIR}
-	#COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_OBJECTS:CudaPTX> ${CUDA_FILES_OUTPUT_DIR}
+	#COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_OBJECTS:CUDAShaders> ${CUDA_FILES_OUTPUT_DIR}
+	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_OBJECTS:CUDAShaders> ${CUDA_FILES_OUTPUT_DIR} &&
+			${CMAKE_COMMAND} -E echo "[INFO]: Copied $<TARGET_OBJECTS:CUDAShaders> to ${CUDA_FILES_OUTPUT_DIR}"
 	DEPENDS CUDAShaders
 	VERBATIM
 	COMMAND_EXPAND_LISTS)

--- a/Lumen_Engine/Sandbox/CMakeLists.txt
+++ b/Lumen_Engine/Sandbox/CMakeLists.txt
@@ -26,7 +26,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
 assign_source_group(${HEADER_FILES})
 assign_source_group(${SOURCE_FILES})
 
-#set_property(TARGET Sandbox PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 set_property(TARGET Sandbox PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 set_property(TARGET Sandbox APPEND PROPERTY COMPILE_DEFINITIONS GLFW_INCLUDE_NONE)
 
@@ -51,6 +50,13 @@ add_custom_command(TARGET Sandbox POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         "${CMAKE_CURRENT_SOURCE_DIR}/../LumenPT/vendor/Dlls"
         $<TARGET_FILE_DIR:Sandbox>)
+
+get_property(WORKING_DIR TARGET Sandbox PROPERTY VS_DEBUGGER_WORKING_DIRECTORY)
+
+add_custom_command(TARGET Sandbox POST_BUILD
+	COMMAND if exist "${WORKING_DIR}/Config.json" 
+			${CMAKE_COMMAND} -E rm "${WORKING_DIR}/Config.json" &&
+			${CMAKE_COMMAND} -E echo "[INFO]: Cleaned up ${WORKING_DIR}/Config.json")
 
 if(${USE_NVIDIA_DENOISER})
 	add_custom_command(TARGET Sandbox POST_BUILD


### PR DESCRIPTION
- Clean up old shader files before copying the new shader files.
- Clean up Config.json in running directory after building to prevent wrong filepaths to shaders.